### PR TITLE
chore: drop older version of node.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-            node-version: [14.x, 16.x, 18.x]
+            node-version: [18.x, 20.x]
 
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
drop v14 and v16 from github actions.