### PR TITLE
fix: set pre style when overflow

### DIFF
--- a/dist/style.css
+++ b/dist/style.css
@@ -110,6 +110,7 @@ header {
   word-break: break-all;
   z-index: 1;
   background-color: #293D52;
+  max-width: 100%;
 }
 .js .filename {
   border: 1px solid #ffff00;
@@ -138,6 +139,7 @@ summary {
   background-color: #333;
   padding: 4px 8px 6px;
   border-radius: 4px;
+  overflow-x: auto;
 }
 .file__meta {
   display: block;


### PR DESCRIPTION
<img width="833" alt="スクリーンショット 2025-05-22 23 15 39" src="https://github.com/user-attachments/assets/528e2970-ed4c-4c5c-ac37-27b6ce16176c" />

with long Props string, it breaks the container