### PR TITLE
Chore/fix publish workflow

### DIFF
--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -47,12 +47,12 @@ jobs:
         with:
           name: artifacts
       # publish for npm package.
-      - run: npm publish
+      - run: npm publish --provenance
       # publish for GitHub Package.
       - uses: actions/setup-node@395ad3262231945c25e8478fd5baf05154b1d79f # v6.1.0
         with:
           registry-url: 'https://npm.pkg.github.com'
           scope: '@tkskto'
-      - run: npm publish
+      - run: npm publish --provenance
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -9,7 +9,6 @@
     "vca": "bin/analyze.js"
   },
   "scripts": {
-    "prepare": "husky",
     "dev": "run-p dev:*",
     "dev:typeScript": "tsc -p src/server/tsconfig.json -w",
     "dev:rollup": "rollup --config -w",


### PR DESCRIPTION
npm publish時にprepareコマンドが実行されてpublishが失敗しているため調整。

ついでに provenance を追加。